### PR TITLE
feat(frontend): lazy-load description modal and HLS player

### DIFF
--- a/frontend/src/views/App.tsx
+++ b/frontend/src/views/App.tsx
@@ -8,7 +8,9 @@ import {
 	createEffect,
 	createMemo,
 	createSignal,
+	lazy,
 	Show,
+	Suspense,
 } from "solid-js";
 import { funnySlogansHaha } from "../funnySlogansHaha";
 import type { RadioState } from "../radio";
@@ -27,8 +29,13 @@ import {
 import type { ProgramInfo } from "../types";
 import classes from "./App.module.css";
 import { Channels } from "./channels/Channels";
-import { Description } from "./description/Description";
 import { PlayerBar } from "./player/PlayerBar";
+
+const Description = lazy(() =>
+	import("./description/Description").then((module) => ({
+		default: module.Description,
+	})),
+);
 
 const App: Component = () => {
 	const radios = useRadiosState();
@@ -120,10 +127,12 @@ const App: Component = () => {
 					</div>
 					<Show when={selectedProgram()}>
 						{(selected) => (
-							<Description
-								programInfo={selected()}
-								setSelectedProgram={setSelectedProgram}
-							/>
+							<Suspense fallback={null}>
+								<Description
+									programInfo={selected()}
+									setSelectedProgram={setSelectedProgram}
+								/>
+							</Suspense>
 						)}
 					</Show>
 					<PlayerBar radioState={radioState} setIsPlaying={setIsPlaying} />

--- a/frontend/src/views/player/PlayerBar.tsx
+++ b/frontend/src/views/player/PlayerBar.tsx
@@ -2,9 +2,11 @@ import {
 	type Accessor,
 	createMemo,
 	createSignal,
+	lazy,
 	Match,
 	type Setter,
 	Show,
+	Suspense,
 	Switch,
 } from "solid-js";
 import { getProgramProgress } from "../../getProgramProgress";
@@ -15,9 +17,14 @@ import { PlayButton } from "../common/PlayButton";
 import { ProgressBar } from "../common/ProgressBar";
 import { AudioPlayer } from "./AudioPlayer";
 import { getHlsStreamUrl } from "./audioPlayerCommon";
-import { HlsAudioPlayer } from "./HlsAudioPlayer";
 import classes from "./PlayerBar.module.css";
 import { VolumeSlider } from "./VolumeSlide";
+
+const HlsAudioPlayer = lazy(() =>
+	import("./HlsAudioPlayer").then((module) => ({
+		default: module.HlsAudioPlayer,
+	})),
+);
 
 interface Props {
 	radioState: Accessor<RadioState | undefined>;
@@ -75,13 +82,15 @@ export function PlayerBar(props: Props) {
 					<>
 						<Switch>
 							<Match when={isHlsChannel()}>
-								<HlsAudioPlayer
-									radio={() => state().radio}
-									isPlaying={isPlaying}
-									volume={volume}
-									nowPlaying={() => state().currentProgram}
-									setIsPlaying={props.setIsPlaying}
-								/>
+								<Suspense fallback={null}>
+									<HlsAudioPlayer
+										radio={() => state().radio}
+										isPlaying={isPlaying}
+										volume={volume}
+										nowPlaying={() => state().currentProgram}
+										setIsPlaying={props.setIsPlaying}
+									/>
+								</Suspense>
 							</Match>
 							<Match when={true}>
 								<AudioPlayer


### PR DESCRIPTION
## Why
The initial bundle included code paths that are not needed at first paint. Deferring them improves startup performance while preserving existing behavior.

## What changed
- lazy-load Description in App and render it under Suspense only when a program modal is opened
- lazy-load HlsAudioPlayer in PlayerBar and render it under Suspense only for HLS channels
- keep core channel list/player shell eager so first render remains responsive

## Bundle size impact (pnpm build)
### Before
- dist/assets/index-Qs5LJ1eh.js: **644.83 kB** (**203.54 kB gzip**)
- dist/assets/index-C5fHmoax.css: **9.77 kB** (**2.90 kB gzip**)

### After
- dist/assets/index-B2ilXo8C.js: **121.61 kB** (**41.42 kB gzip**)
- dist/assets/index-DqTf25Am.css: **8.01 kB** (**2.48 kB gzip**)
- dist/assets/HlsAudioPlayer-CAvOjYzb.js: **521.74 kB** (**161.76 kB gzip**)
- dist/assets/Description-z0t2ETbm.js: **3.33 kB** (**1.43 kB gzip**)
- dist/assets/Description-D_zNsMCG.css: **2.17 kB** (**0.82 kB gzip**)

## Validation
- pnpm lint
- pnpm build